### PR TITLE
feat: creates input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
   },
   "dependencies": {
+    "@jamescoyle/vue-icon": "^0.1.2",
+    "@mdi/js": "^7.2.96",
     "axios": "^1.2.3",
     "pinia": "^2.0.28",
     "vue": "^3.2.45",

--- a/src/components/forms/ContentInput.vue
+++ b/src/components/forms/ContentInput.vue
@@ -21,7 +21,7 @@ const props = defineProps({
     default: 'textarea',
   },
   label: String,
-  input: Object,
+  attributes: Object,
 });
 
 function insertAttributesIntoInputElement(attributes) {
@@ -43,7 +43,7 @@ function handleInput() {
 }
 
 onMounted(() => {
-  insertAttributesIntoInputElement(props.input);
+  insertAttributesIntoInputElement(props.attributes);
 });
 </script>
 

--- a/src/components/forms/ContentInput.vue
+++ b/src/components/forms/ContentInput.vue
@@ -35,7 +35,7 @@ function validation() {
     return errorMessage.value = '';
   }
 
-  errorMessage.value = 'Some examples of errors';
+  errorMessage.value = textarea.value.validationMessage;
 }
 
 function handleInput() {

--- a/src/components/forms/ContentInput.vue
+++ b/src/components/forms/ContentInput.vue
@@ -1,0 +1,92 @@
+<template>
+  <label class="label">
+    <div class="describe">
+      {{ label }}
+    </div>
+
+    <textarea ref="textarea" class="textarea" @input="handleInput"></textarea>
+
+    <div class="message" :data-message="errorMessage"></div>
+  </label>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+
+const textarea = ref(null);
+const errorMessage = ref('');
+const props = defineProps({
+  validityType: {
+    type: String,
+    default: 'textarea',
+  },
+  label: String,
+  input: Object,
+});
+
+function insertAttributesIntoInputElement(attributes) {
+  for (const attr in attributes) {
+    textarea.value.setAttribute(attr, attributes[attr]);
+  }
+}
+
+function validation() {
+  if (textarea.value.checkValidity()) {
+    return errorMessage.value = '';
+  }
+
+  errorMessage.value = 'Some examples of errors';
+}
+
+function handleInput() {
+  validation();
+}
+
+onMounted(() => {
+  insertAttributesIntoInputElement(props.input);
+});
+</script>
+
+<style scoped lang="scss">
+.label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: .5rem;
+  color: var(--text-principal);
+}
+
+.describe,
+.message {
+  font-weight: 600;
+}
+
+.textarea {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 1rem;
+  width: 100%;
+  min-height: 500px;
+  color: var(--text-principal);
+  border-radius: 9px;
+  border: 2px solid var(--login-field-border-color);
+  background-color: var(--login-field-background-color);
+
+  &::placeholder {
+    color: var(--login-field-color);
+  }
+}
+
+.message {
+  width: 100%;
+  font-size: .8rem;
+  color: var(--red-200);
+
+  &::after {
+    content: attr(data-message);
+  }
+}
+</style>

--- a/src/components/forms/ContentInput.vue
+++ b/src/components/forms/ContentInput.vue
@@ -4,7 +4,7 @@
       {{ label }}
     </div>
 
-    <textarea ref="textarea" class="textarea" @input="handleInput"></textarea>
+    <textarea ref="textareaRef" class="textarea" @input="handleInput"></textarea>
 
     <div class="message" :data-message="errorMessage"></div>
   </label>
@@ -13,7 +13,7 @@
 <script setup>
 import { ref, onMounted } from 'vue';
 
-const textarea = ref(null);
+const textareaRef = ref(null);
 const errorMessage = ref('');
 const props = defineProps({
   validityType: {
@@ -26,16 +26,18 @@ const props = defineProps({
 
 function insertAttributesIntoInputElement(attributes) {
   for (const attr in attributes) {
-    textarea.value.setAttribute(attr, attributes[attr]);
+    textareaRef.value.setAttribute(attr, attributes[attr]);
   }
 }
 
 function validation() {
-  if (textarea.value.checkValidity()) {
+  if (textareaRef.value.checkValidity()) {
+    textareaRef.value.classList.remove('error');
     return errorMessage.value = '';
   }
 
-  errorMessage.value = textarea.value.validationMessage;
+  textareaRef.value.classList.add('error');
+  errorMessage.value = textareaRef.value.validationMessage;
 }
 
 function handleInput() {
@@ -75,12 +77,17 @@ onMounted(() => {
   border: 2px solid var(--login-field-border-color);
   background-color: var(--login-field-background-color);
 
+  &.error {
+    outline: solid var(--red-200);
+  }
+
   &::placeholder {
     color: var(--login-field-color);
   }
 }
 
 .message {
+  padding: 0 .5rem;
   width: 100%;
   font-size: .8rem;
   color: var(--red-200);

--- a/src/components/forms/ContentInput.vue
+++ b/src/components/forms/ContentInput.vue
@@ -16,10 +16,6 @@ import { ref, onMounted } from 'vue';
 const textareaRef = ref(null);
 const errorMessage = ref('');
 const props = defineProps({
-  validityType: {
-    type: String,
-    default: 'textarea',
-  },
   label: String,
   attributes: Object,
 });
@@ -33,7 +29,8 @@ function insertAttributesIntoInputElement(attributes) {
 function validation() {
   if (textareaRef.value.checkValidity()) {
     textareaRef.value.classList.remove('error');
-    return errorMessage.value = '';
+    errorMessage.value = '';
+    return;
   }
 
   textareaRef.value.classList.add('error');

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -1,0 +1,160 @@
+<template>
+  <label class="label">
+    <div class="describe">
+      {{ label }}
+    </div>
+
+    <div class="input">
+      <input ref="input" class="input-field" @input="handleInput"/>
+
+      <button
+        type="button"
+        class="input-button"
+        :disabled="Boolean(!icon)"
+        @click="handleClick"
+      >
+        <svg-icon type="mdi" :path="icon" />
+      </button>
+    </div>
+
+    <div class="message" :data-message="errorMessage"></div>
+  </label>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import SvgIcon from '@jamescoyle/vue-icon';
+
+const input = ref(null);
+const errorMessage = ref('');
+const props = defineProps({
+  validityType: {
+    type: String,
+    default: 'text',
+  },
+  label: String,
+  input: {
+    type: Object,
+    default() {
+      return { type: 'text' };
+    },
+  },
+  icon: {
+    type: String,
+    default: '',
+  },
+});
+
+function insertAttributesIntoInputElement(attributes) {
+  for (const attr in attributes) {
+    input.value.setAttribute(attr, attributes[attr]);
+  }
+}
+
+function handleClick() {
+  input.value.type = input.value.type === 'password' ? 'text' : 'password';
+}
+
+function validation() {
+  if (input.value.checkValidity()) {
+    return errorMessage.value = '';
+  }
+
+  errorMessage.value = 'Some examples of errors';
+}
+
+function handleInput() {
+  validation();
+}
+
+onMounted(() => {
+  insertAttributesIntoInputElement(props.input);
+});
+</script>
+
+<style scoped lang="scss">
+.label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: .5rem;
+  color: var(--text-principal);
+}
+
+.describe,
+.message {
+  font-weight: 600;
+}
+
+.input {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-radius: 9px;
+  border: 2px solid var(--login-field-border-color);
+  background-color: var(--login-field-background-color);
+
+  &-field,
+  &-button {
+    border-radius: 5px;
+    background-color: var(--login-field-background-color) red;
+  }
+
+  &-field {
+    margin: 0 2px;
+    padding: .5rem 1rem;
+    width: 100%;
+    color: var(--text-principal);
+    border: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &::placeholder {
+      color: var(--login-field-color);
+    }
+  }
+
+  &-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: .5rem 1rem;
+    font-size: 1rem;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    transition: background-color .2s, color .2s;
+  }
+
+  &-button:disabled {
+    padding: .5rem 0;
+    width: 0;
+    border: none;
+  }
+
+  &-field[type='password'] + &-button:not(disabled) {
+    &:hover {
+      color: var(--login-field-color-hover);
+      border-color: var(--login-field-border-color-hover);
+      background-color: var(--login-field-background-color-hover);
+    }
+
+    &:active {
+      border-color: var(--login-field-border-color-active);
+      background-color: var(--login-field-background-color-active);
+    }
+  }
+}
+
+.message {
+  width: 100%;
+  font-size: .8rem;
+  color: var(--red-200);
+
+  &::after {
+    content: attr(data-message);
+  }
+}
+</style>

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -60,7 +60,7 @@ function validation() {
     return errorMessage.value = '';
   }
 
-  errorMessage.value = 'Some examples of errors';
+  errorMessage.value = input.value.validationMessage;
 }
 
 function handleInput() {
@@ -149,6 +149,7 @@ onMounted(() => {
 }
 
 .message {
+  padding: 0 .5rem;
   width: 100%;
   font-size: .8rem;
   color: var(--red-200);

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -33,7 +33,7 @@ const props = defineProps({
     default: 'text',
   },
   label: String,
-  input: {
+  attributes: {
     type: Object,
     default() {
       return { type: 'text' };
@@ -68,7 +68,7 @@ function handleInput() {
 }
 
 onMounted(() => {
-  insertAttributesIntoInputElement(props.input);
+  insertAttributesIntoInputElement(props.attributes);
 });
 </script>
 

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -4,8 +4,8 @@
       {{ label }}
     </div>
 
-    <div class="input">
-      <input ref="input" class="input-field" @input="handleInput"/>
+    <div ref="inputBoxRef" class="input">
+      <input ref="inputRef" class="input-field" @input="handleInput"/>
 
       <button
         type="button"
@@ -25,7 +25,8 @@
 import { ref, onMounted } from 'vue';
 import SvgIcon from '@jamescoyle/vue-icon';
 
-const input = ref(null);
+const inputBoxRef = ref(null);
+const inputRef = ref(null);
 const errorMessage = ref('');
 const props = defineProps({
   validityType: {
@@ -47,20 +48,22 @@ const props = defineProps({
 
 function insertAttributesIntoInputElement(attributes) {
   for (const attr in attributes) {
-    input.value.setAttribute(attr, attributes[attr]);
+    inputRef.value.setAttribute(attr, attributes[attr]);
   }
 }
 
 function handleClick() {
-  input.value.type = input.value.type === 'password' ? 'text' : 'password';
+  inputRef.value.type = inputRef.value.type === 'password' ? 'text' : 'password';
 }
 
 function validation() {
-  if (input.value.checkValidity()) {
+  if (inputRef.value.checkValidity()) {
+    inputBoxRef.value.classList.remove('error');
     return errorMessage.value = '';
   }
 
-  errorMessage.value = input.value.validationMessage;
+  inputBoxRef.value.classList.add('error');
+  errorMessage.value = inputRef.value.validationMessage;
 }
 
 function handleInput() {
@@ -96,6 +99,10 @@ onMounted(() => {
   border: 2px solid var(--login-field-border-color);
   background-color: var(--login-field-background-color);
 
+  &.error {
+    border-color: var(--red-200);
+  }
+
   &-field,
   &-button {
     border-radius: 5px;
@@ -130,8 +137,8 @@ onMounted(() => {
 
   &-button:disabled {
     padding: .5rem 0;
-    width: 0;
-    border: none;
+    width: 1px;
+    opacity: 0;
   }
 
   &-field[type='password'] + &-button:not(disabled) {

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -10,7 +10,8 @@
       <button
         type="button"
         class="input-button"
-        :disabled="Boolean(!icon)"
+        :disabled="Boolean(!enableButton)"
+        :data-hidden="Boolean(!icon)"
         @click="handleClick"
       >
         <svg-icon type="mdi" :path="icon" />
@@ -29,10 +30,6 @@ const inputBoxRef = ref(null);
 const inputRef = ref(null);
 const errorMessage = ref('');
 const props = defineProps({
-  validityType: {
-    type: String,
-    default: 'text',
-  },
   label: String,
   attributes: {
     type: Object,
@@ -43,6 +40,10 @@ const props = defineProps({
   icon: {
     type: String,
     default: '',
+  },
+  enableButton: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -59,7 +60,8 @@ function handleClick() {
 function validation() {
   if (inputRef.value.checkValidity()) {
     inputBoxRef.value.classList.remove('error');
-    return errorMessage.value = '';
+    errorMessage.value = '';
+    return;
   }
 
   inputBoxRef.value.classList.add('error');
@@ -106,7 +108,7 @@ onMounted(() => {
   &-field,
   &-button {
     border-radius: 5px;
-    background-color: var(--login-field-background-color) red;
+    background-color: var(--login-field-background-color);
   }
 
   &-field {
@@ -133,24 +135,29 @@ onMounted(() => {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     transition: background-color .2s, color .2s;
-  }
 
-  &-button:disabled {
-    padding: .5rem 0;
-    width: 1px;
-    opacity: 0;
-  }
-
-  &-field[type='password'] + &-button:not(disabled) {
-    &:hover {
-      color: var(--login-field-color-hover);
-      border-color: var(--login-field-border-color-hover);
-      background-color: var(--login-field-background-color-hover);
+    &[data-hidden=true] {
+      padding: .5rem 0;
+      width: 1px;
+      opacity: 0;
     }
 
-    &:active {
-      border-color: var(--login-field-border-color-active);
-      background-color: var(--login-field-background-color-active);
+    &:disabled {
+      pointer-events: none;
+    }
+
+    &:not(:disabled) {
+      &:hover {
+        color: var(--login-field-color-hover);
+        border-color: var(--login-field-border-color-hover);
+        background-color: var(--login-field-background-color-hover);
+      }
+
+      &:active {
+        color: var(--login-field-color-active);
+        border-color: var(--login-field-border-color-active);
+        background-color: var(--login-field-background-color-active);
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,6 +151,16 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@jamescoyle/vue-icon@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@jamescoyle/vue-icon/-/vue-icon-0.1.2.tgz#b9e254187de6716b81bf9e0e8400ec012231bd05"
+  integrity sha512-KFrImXx5TKIi6iQXlnyLEBl4rNosNKbTeRnr70ucTdUaciVmd9qK9d/pZAaKt1Ob/8xNnX2GMp8LisyHdKtEgw==
+
+"@mdi/js@^7.2.96":
+  version "7.2.96"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-7.2.96.tgz#a2a20be740a75e65c8b8b9e12a2b699c06a9208f"
+  integrity sha512-paR9M9ZT7rKbh2boksNUynuSZMHhqRYnEZOm/KrZTjQ4/FzyhjLHuvw/8XYzP+E7fS4+/Ms/82EN1pl/OFsiIA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
### Descrição
Cria dois componentes, um *input* comum para os textos curtos e um *textarea* para a escrita das cartas.

As mensagens de erro usadas estão vindo da API padrão disponível em 97.3% dos navegadores. (futuramente as mensagens serão personalizadas).

#### ContentInput
- **label**: Recebe o nome do campo.
- **attributes**: Um objeto com os atributos do *textarea*.

#### TextInput
- **label**: Recebe o nome do dado esperado.
- **attributes**: Um objeto com os atributos do input.
- **icon**: Recebe um ícone que está disponível no pacote @mdi/js.
- **enableButton**: Ativa a ação de alterar a visibilidade da senha. Alterna entre ['password' <> 'text'].

### Preview
![Frame 232](https://github.com/Minnemi/minnemi-front/assets/48590313/cd2b04e0-46d5-4440-9a55-2927245e64d2)
![Frame 231](https://github.com/Minnemi/minnemi-front/assets/48590313/37d92d7d-d6e4-4245-a49c-54611c2b3752)

Issue #12 